### PR TITLE
Autocreate file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ return {
         local whip = require("whip")
         whip.setup({
             -- its probs a good idea to have a dir dedicated to your scratchpads
-            dir = "~/your/whip/dir/goes-here"
+            dir = "~/your/whip/dir/goes-here",
+            autocreate = true -- Autocreates a whip file if it doesn't already exist when using whip.find_file
         })
         vim.keymap.set("", "<leader>wo", whip.open, { desc = "[W]hip [O]pen" })
         vim.keymap.set("", "<leader>wm", whip.make, { desc = "[W]hip [M]ake" })

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ return {
         whip.setup({
             -- its probs a good idea to have a dir dedicated to your scratchpads
             dir = "~/your/whip/dir/goes-here",
-            autocreate = true -- Autocreates a whip file if it doesn't already exist when using whip.find_file
+            autocreate = true -- Autocreates a whip file if the results list is empty when using whip.find_file
         })
         vim.keymap.set("", "<leader>wo", whip.open, { desc = "[W]hip [O]pen" })
         vim.keymap.set("", "<leader>wm", whip.make, { desc = "[W]hip [M]ake" })

--- a/lua/whip/init.lua
+++ b/lua/whip/init.lua
@@ -8,6 +8,7 @@ local M = {}
 local state = {
     dir = nil,
     config_path = nil,
+    config_autocreate = false,
     health_data = {
         is_setup = false,
         dir_err = nil,
@@ -137,6 +138,12 @@ M.find_file = function()
         attach_mappings = function(prompt_bufnr, _)
             ts_actions.select_default:replace(function()
                 local selection = ts_action_state.get_selected_entry()
+                if not selection and state.config_autocreate then
+                    local newfile = ts_action_state.get_current_line()
+                    current_set(newfile)
+                    vim.cmd(string.format("edit! %s/%s", state.dir, newfile))
+                    return true
+                end
                 local filename = selection[1]
                 if is_empty(filename) then
                     return log_error("no file selecetd")
@@ -230,6 +237,9 @@ M.setup = function(opts)
     end
     if not plenary_found then
         return log_error_dep_not_found("plenary")
+    end
+    if opts.autocreate then
+        state.config_autocreate = opts.autocreate
     end
     if opts.dir then
         dir_set(opts.dir)


### PR DESCRIPTION
 Adds the option to auto-create a file if the results list is empty when using whip.find_file()
 
 Could be improved further by also having a keybinding to create the file even when the results list is not empty (without leaving the current telescope search and using the make() function).